### PR TITLE
Remove jam sessions option from the menu

### DIFF
--- a/features/main/hud/src/main/java/com/vgleadsheets/features/main/hud/menu/MenuOptions.kt
+++ b/features/main/hud/src/main/java/com/vgleadsheets/features/main/hud/menu/MenuOptions.kt
@@ -78,13 +78,12 @@ object MenuOptions {
             R.drawable.ic_shuffle_24dp,
             { onRandomClick() }
         ),
-        MenuItemListModel(
-            resources.getString(R.string.label_jams),
-            null,
-            R.drawable.ic_queue_music_black_24dp,
-            { onScreenLinkClick(HudFragment.TOP_LEVEL_SCREEN_ID_JAM) }
-        ),
-
+//        MenuItemListModel(
+//            resources.getString(R.string.label_jams),
+//            null,
+//            R.drawable.ic_queue_music_black_24dp,
+//            { onScreenLinkClick(HudFragment.TOP_LEVEL_SCREEN_ID_JAM) }
+//        ),
         MenuItemListModel(
             resources.getString(R.string.label_settings),
             null,


### PR DESCRIPTION
Effectively makes the feature developer-only.

![Screenshot_1678281910](https://user-images.githubusercontent.com/1912034/223725165-296e18af-deab-461d-a928-f1423b77b747.png)
