### PR TITLE
Refresh DB before starting offline downloads

### DIFF
--- a/app/src/main/java/com/vgleadsheets/di/OfflineModule.kt
+++ b/app/src/main/java/com/vgleadsheets/di/OfflineModule.kt
@@ -4,6 +4,7 @@ import com.vgleadsheets.downloader.SheetDownloader
 import com.vgleadsheets.logging.Hatchet
 import com.vgleadsheets.offline.OfflineDownloader
 import com.vgleadsheets.repository.OfflineRepository
+import com.vgleadsheets.repository.UpdateManager
 import com.vgleadsheets.time.ThreeTenTime
 import dagger.Module
 import dagger.Provides
@@ -21,10 +22,12 @@ object OfflineModule {
         sheetDownloader: SheetDownloader,
         threeTenTime: ThreeTenTime,
         hatchet: Hatchet,
+        updateManager: UpdateManager,
     ): OfflineDownloader = OfflineDownloader(
         offlineRepo = offlineRepository,
         sheetDownloader = sheetDownloader,
         threeTenTime = threeTenTime,
         hatchet = hatchet,
+        updateManager = updateManager,
     )
 }

--- a/core/common/model/src/main/java/com/vgleadsheets/model/updates/OfflineJobStatus.kt
+++ b/core/common/model/src/main/java/com/vgleadsheets/model/updates/OfflineJobStatus.kt
@@ -3,4 +3,5 @@ package com.vgleadsheets.model.updates
 enum class OfflineJobStatus {
     COMPLETED,
     ABORTED,
+    ABORTED_REFRESH_FAILED,
 }

--- a/core/common/offline/src/main/java/com/vgleadsheets/offline/OfflineDownloader.kt
+++ b/core/common/offline/src/main/java/com/vgleadsheets/offline/OfflineDownloader.kt
@@ -6,6 +6,7 @@ import com.vgleadsheets.model.Part
 import com.vgleadsheets.model.Song
 import com.vgleadsheets.model.updates.OfflineJobStatus
 import com.vgleadsheets.repository.OfflineRepository
+import com.vgleadsheets.repository.UpdateManager
 import com.vgleadsheets.time.ThreeTenTime
 import kotlinx.coroutines.flow.first
 
@@ -14,8 +15,16 @@ class OfflineDownloader(
     private val sheetDownloader: SheetDownloader,
     private val threeTenTime: ThreeTenTime,
     private val hatchet: Hatchet,
+    private val updateManager: UpdateManager,
 ) {
     suspend fun checkAll() {
+        val refreshSucceeded = updateManager.refreshAndAwait()
+        if (!refreshSucceeded) {
+            hatchet.e("DB refresh failed — aborting offline download.")
+            offlineRepo.insertUpdateResult(0, OfflineJobStatus.ABORTED_REFRESH_FAILED)
+            return
+        }
+
         var consecutiveFailures = 0
         var successfulOfflines = 0
 

--- a/core/common/repository/src/main/java/com/vgleadsheets/repository/UpdateManager.kt
+++ b/core/common/repository/src/main/java/com/vgleadsheets/repository/UpdateManager.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.flowOn
@@ -89,15 +90,23 @@ class UpdateManager(
         return lastCheckAge > AGE_THRESHOLD
     }
 
+    @Suppress("ReturnCount")
+    suspend fun refreshAndAwait(): Boolean {
+        if (!refreshLastApiUpdateTime()) return false
+        val needsUpdate = dbUpdateTimeCheckFlow().first()
+        if (!needsUpdate) return true
+        return refreshInternal().first()
+    }
+
     @Suppress("TooGenericExceptionCaught")
-    private suspend fun refreshLastApiUpdateTime() {
+    private suspend fun refreshLastApiUpdateTime(): Boolean {
         hatchet.i("Requesting API update time check...")
 
         val lastUpdate = try {
             vglsApi.getLastUpdateTime()
         } catch (ex: Exception) {
             emitApiUpdateErrors(ex)
-            return
+            return false
         }
 
         val lastUpdateInstant = Instant.parse(lastUpdate.last_updated)
@@ -115,6 +124,7 @@ class UpdateManager(
 
         dbStatisticsDataSource.insert(lastUpdateTime)
         dbStatisticsDataSource.insert(lastAppCheckTime)
+        return true
     }
 
     private fun dbUpdateTimeCheckFlow() = combine(


### PR DESCRIPTION
OfflineDownloader now calls refreshAndAwait() before processing sheets, aborting with ABORTED_REFRESH_FAILED if the API update check fails.